### PR TITLE
improve watch evaluation

### DIFF
--- a/lib/commands/eval-javascript-watch.js
+++ b/lib/commands/eval-javascript-watch.js
@@ -67,7 +67,6 @@ function evaluateJavaScriptWatchAction(scriptPath, options) {
 function evaluateJavaScriptWatchCommand(program) {
   program.command('eval:watch <path>')
     .description('Evaluates a JavaScript Watcher file and prints out the result')
-    // .option('-p, --path <path>', 'Watch Js file path')
     .option('--project-id <project id>', 'Set the project id. A prefix to avoid conflicts')
     .action(evaluateJavaScriptWatchAction)
 }

--- a/lib/commands/eval-javascript-watch.js
+++ b/lib/commands/eval-javascript-watch.js
@@ -15,18 +15,18 @@ const fileExists = (filePath) => {
   }
 };
 
-function evaluateJavaScriptWatchAction(options) {
-  if (!options.path) {
+function evaluateJavaScriptWatchAction(scriptPath, options) {
+  if (!scriptPath) {
     container.logger.error('Path to the file is required. Define it using -p option');
     return;
   }
 
-  if (!fileExists(options.path)) {
-    container.logger.error(`The file '${options.path}' could not be found`);
+  if (!fileExists(scriptPath)) {
+    container.logger.error(`The file '${scriptPath}' could not be found`);
     return;
   }
 
-  const fileExtention = path.extname(options.path);
+  const fileExtention = path.extname(scriptPath);
 
   if (fileExtention !== '.cjs' && fileExtention !== '.js') {
     if (fileExtention === '.mjs') {
@@ -38,8 +38,8 @@ function evaluateJavaScriptWatchAction(options) {
     return;
   }
 
-  const pieces = options.path.split('/');
-  const fullPath = path.resolve(options.path);
+  const pieces = scriptPath.split('/');
+  const fullPath = path.resolve(scriptPath);
 
   process.chdir(fullPath.split('/').slice(0, -1).join('/') + '/../../..');
   container.logger.info(`Changing current directory to ${process.cwd()}`);
@@ -65,9 +65,9 @@ function evaluateJavaScriptWatchAction(options) {
 }
 
 function evaluateJavaScriptWatchCommand(program) {
-  program.command('eval:watch')
-    .description('Evaluates a JavaScript Watcher file and print out the result')
-    .option('-p, --path <path>', 'Watch Js file path')
+  program.command('eval:watch <path>')
+    .description('Evaluates a JavaScript Watcher file and prints out the result')
+    // .option('-p, --path <path>', 'Watch Js file path')
     .option('--project-id <project id>', 'Set the project id. A prefix to avoid conflicts')
     .action(evaluateJavaScriptWatchAction)
 }


### PR DESCRIPTION
This PR makes `eval:watch` command to accept a `<path>` directly instead of expecting an option